### PR TITLE
fix: Resolve compilation error and fix lint warning

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
             </p>
           </div>
         </div>
-        <RollingGallery autoplay={true} pauseOnHover={true} />
+        <RollingGallery autoplay={true} />
       </section>
 
       {/* Registration Popup */}

--- a/src/components/Layout/StickyFooter.tsx
+++ b/src/components/Layout/StickyFooter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { UserPlus, Sparkles } from 'lucide-react';
+import { UserPlus } from 'lucide-react';
 
 interface StickyFooterProps {
   onRegisterClick?: () => void;


### PR DESCRIPTION
This commit fixes a TypeScript compilation error in `src/app/page.tsx` that was caused by a missing prop on the `RollingGallery` component. The `pauseOnHover` prop was removed from the component's definition but not from its invocation.

It also fixes a new linting warning for an unused import in `src/components/Layout/StickyFooter.tsx`.